### PR TITLE
Adding hash splat to remove the ruby 2.7 warning

### DIFF
--- a/lib/comfortable_mexican_sofa/routing.rb
+++ b/lib/comfortable_mexican_sofa/routing.rb
@@ -6,7 +6,7 @@ require_relative "routes/cms"
 class ActionDispatch::Routing::Mapper
 
   def comfy_route(identifier, options = {})
-    send("comfy_route_#{identifier}", options)
+    send("comfy_route_#{identifier}", **options)
   end
 
 end


### PR DESCRIPTION
Adding `hash splat` (**) to options hash inside `comfy_route` method, to remove the ruby 2.7 warning